### PR TITLE
Add pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,9 @@
+{
+	"user": "Wuzi",
+	"repo": "dynamicgz",
+	"entry": "gz_creator.pwn",
+	"output": "gz_creator.amx",
+	"dependencies": [
+		"sampctl/samp-stdlib"
+	]
+}


### PR DESCRIPTION
Allows including `dynamicgz.inc` as a sampctl dependency or directly build the package with `gz_creator.pwn` (using `sampctl package build` and `sampctl package run`)